### PR TITLE
Catch doctrine exceptions

### DIFF
--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -102,10 +102,10 @@ class FlowContext extends BehatContext
     {
         if (self::$bootstrap !== null) {
             try {
-				self::$bootstrap->shutdown('Runtime');
-			} catch(\Doctrine\ORM\ORMInvalidArgumentException $e) {
-				//ignore this tye of exceptions
-			}
+                self::$bootstrap->shutdown('Runtime');
+	    } catch(\Doctrine\ORM\ORMInvalidArgumentException $e) {
+	        //ignore this tye of exceptions
+            }
         }
     }
 

--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -101,7 +101,11 @@ class FlowContext extends BehatContext
     public static function shutdownFlow()
     {
         if (self::$bootstrap !== null) {
-            self::$bootstrap->shutdown('Runtime');
+            try {
+				self::$bootstrap->shutdown('Runtime');
+			} catch(\Doctrine\ORM\ORMInvalidArgumentException $e) {
+				//ignore this tye of exceptions
+			}
         }
     }
 


### PR DESCRIPTION
Sometimes it`s not worth the work to find what introduces this detached entity through the tests. The easiest is to ignore this failure in shutdown.