### PR TITLE
TASK: Use PackageManager, not PackageManagerInterface

### DIFF
--- a/Classes/Command/BehatCommandController.php
+++ b/Classes/Command/BehatCommandController.php
@@ -22,7 +22,7 @@ class BehatCommandController extends CommandController
 {
 
     /**
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var \Neos\Flow\Package\PackageManager
      * @Flow\Inject
      */
     protected $packageManager;


### PR DESCRIPTION
The PackageManagerInterface is deprecated and will be removed with
Flow 6.0.