### PR TITLE
Bugfix: Do not hide exception when running command

### DIFF
--- a/Tests/Behat/FlowContextTrait.php
+++ b/Tests/Behat/FlowContextTrait.php
@@ -118,9 +118,7 @@ trait FlowContextTrait
             $this->lastCommandOutput = $captureAspect->getCapturedOutput();
 
             $this->persistAll();
-
-            $captureAspect->enableOutput();
-        } catch (\Exception $e) {
+        } finally {
             $captureAspect->enableOutput();
         }
     }


### PR DESCRIPTION
If a command is run and throws an exception it must not be catched. Better use `finally` to just make sure output is enabled (which is always enabled anyway until #19 is merged).