### PR TITLE
BUGFIX: Set PHP constraint to match the require of the behat/behat version in composer.lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "description": "Behat support package for Neos Flow",
     "license": ["LGPL-3.0-or-later"],
     "require": {
+        "php": "^7.2 || ^8.0",
         "neos/flow": "*"
     },
     "autoload": {


### PR DESCRIPTION
That way this neos/behat version will not be installed on PHP <= 7.1 leading to failing to install behat in the `./flow behat:setup` step.
See https://github.com/neos/behat/blob/6.1/Resources/Private/Build/Behat/composer.lock#L27

Related to #23

t.b.d.: can we somehow automate/sync this?