### PR TITLE
BUGFIX: improve Flow booting and mock current Request correctly

### DIFF
--- a/Classes/FlowBootstrapTrait.php
+++ b/Classes/FlowBootstrapTrait.php
@@ -9,8 +9,7 @@ use Neos\Flow\Core\Booting\Exception\SubProcessException;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Testing\RequestHandler\RuntimeSequenceHttpRequestHandler;
-use Neos\Http\Factories\ServerRequestFactory;
-use Neos\Http\Factories\UriFactory;
+use Psr\Http\Message\ServerRequestFactoryInterface;
 
 /**
  * Boot flow in a behat feature context
@@ -62,12 +61,13 @@ trait FlowBootstrapTrait
         $flowBootstrap->registerRequestHandler($requestHandler);
         $flowBootstrap->setPreselectedRequestHandlerClassName($requestHandler::class);
 
-        $serverRequestFactory = new ServerRequestFactory(new UriFactory());
+        $flowBootstrap->run();
+
+        $serverRequestFactory = $flowBootstrap->getObjectManager()->get(ServerRequestFactoryInterface::class);
+
         $request = $serverRequestFactory->createServerRequest('GET', 'http://localhost');
 
         $requestHandler->setHttpRequest($request);
-
-        $flowBootstrap->run();
 
         return self::$bootstrap = $flowBootstrap;
     }

--- a/Classes/FlowBootstrapTrait.php
+++ b/Classes/FlowBootstrapTrait.php
@@ -8,8 +8,9 @@ use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Booting\Exception\SubProcessException;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Tests\FunctionalTestRequestHandler;
+use Neos\Flow\Testing\RequestHandler\RuntimeSequenceHttpRequestHandler;
+use Neos\Http\Factories\ServerRequestFactory;
+use Neos\Http\Factories\UriFactory;
 
 /**
  * Boot flow in a behat feature context
@@ -30,6 +31,9 @@ use Neos\Flow\Tests\FunctionalTestRequestHandler;
  */
 trait FlowBootstrapTrait
 {
+    /**
+     * @internal please use {@see self::getObject()} to get objects
+     */
     private static ?Bootstrap $bootstrap = null;
 
     /**
@@ -50,13 +54,22 @@ trait FlowBootstrapTrait
         if (!defined('BEHAT_ERROR_REPORTING')) {
             define('BEHAT_ERROR_REPORTING', E_ALL);
         }
-        self::$bootstrap = new Bootstrap('Testing/Behat');
-        Scripts::initializeClassLoader(self::$bootstrap);
-        Scripts::initializeSignalSlot(self::$bootstrap);
-        Scripts::initializePackageManagement(self::$bootstrap);
-        self::$bootstrap->setActiveRequestHandler(new FunctionalTestRequestHandler(self::$bootstrap));
-        self::$bootstrap->buildRuntimeSequence()->invoke(self::$bootstrap);
-        return self::$bootstrap;
+
+        // Boot flow with an active request handler
+        $flowBootstrap = new Bootstrap('Testing/Behat');
+        $requestHandler = new RuntimeSequenceHttpRequestHandler($flowBootstrap);
+
+        $flowBootstrap->registerRequestHandler($requestHandler);
+        $flowBootstrap->setPreselectedRequestHandlerClassName($requestHandler::class);
+
+        $serverRequestFactory = new ServerRequestFactory(new UriFactory());
+        $request = $serverRequestFactory->createServerRequest('GET', 'http://localhost');
+
+        $requestHandler->setHttpRequest($request);
+
+        $flowBootstrap->run();
+
+        return self::$bootstrap = $flowBootstrap;
     }
 
     /**

--- a/Classes/FlowEntitiesTrait.php
+++ b/Classes/FlowEntitiesTrait.php
@@ -65,17 +65,6 @@ trait FlowEntitiesTrait
             if ($needsTruncate) {
                 $this->truncateTables($entityManager);
             }
-
-            // TODO Remove this and fix flow
-            // After debugging this a bit with christian, we came further but found not the real source why this doesnt work in testing.
-            // We correctly boot flow and also the buildRuntimeSequence triggers the compileDoctrineProxies
-            // But it seems that the `Flow_Reflection_RuntimeClassSchemata` cache seems to be empty in testing context and we expect it to be filled in `FlowAnnotationDriver.php:118`
-            // This might be because flow is mainly programmed for Production and Development, and in testing skips the cache fillup:
-            // https://github.com/neos/flow-development-collection/blob/53c82370d554b27fac61ba96ec5c3b6015546c1f/Neos.Flow/Classes/Reflection/ReflectionService.php#L1844
-            // But removing this line alone does not fix the issue alone
-            // p.s. dont blame me
-            $proxyFactory = $entityManager->getProxyFactory();
-            $proxyFactory->generateProxyClasses($entityManager->getMetadataFactory()->getAllMetadata());
         }
     }
 


### PR DESCRIPTION
Fixes regression from https://github.com/neos/behat/pull/35#issuecomment-2176596113

In the behat testing context somehow the `SCRIPT_NAME` is set to `../../../bin/` (when running behat like that) resulting the uribuilding to append `../../../bin/` as path to generated uris and the redirect handler tests to fail

The reason for this is that with #35 the active request handler changed from a `CommandRequestHandler` in 8.3 (see https://github.com/neos/behat/blob/572809547ca389080198377e882fa75aadb12209/Tests/Behat/FlowContextTrait.php#L79-L85) to a `FunctionalTestRequestHandler`.
That in turn leads the base uri provider (used by the uribuilder) to pass the http request (from the active request handler `getActiveRequestHandler`) to `RequestInformationHelper::getScriptRequestPathAndFilename`.
As `FunctionalTestRequestHandler::getHttpRequest` will by default return `ServerRequest::fromGlobals()` the `SCRIPT_NAME` will be wrongly set.

The `FunctionalTestRequestHandler` doesnt run into this problem in php unit because there we override the httpRequest via `setHttpRequest` in the `setup`:

https://github.com/neos/flow-development-collection/blob/5256af268a3db0de15cb723e6c120333dc8ff59d/Neos.Flow/Tests/FunctionalTestCase.php#L439-L444

We have to do the same (and even better at the beginning) - to use `ServerRequestFactory->createServerRequest` - which will ensure that uribuilding works correctly.

see also the slack thread https://neos-project.slack.com/archives/C050KKBEB/p1718724415425439