### PR TITLE
BUGFIX: Close connection to reset transaction

### DIFF
--- a/Classes/FlowEntitiesTrait.php
+++ b/Classes/FlowEntitiesTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\Behat;
 
 use Behat\Hook\BeforeScenario;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,9 +37,11 @@ trait FlowEntitiesTrait
     {
         $entityManager = $this->getObject(EntityManagerInterface::class);
         $entityManager->clear();
+        // the same connection as the singleton: $this->getObject(Connection::class);
+        $connection = $entityManager->getConnection();
 
         if (self::$databaseSchema !== null) {
-            $this->truncateTables($entityManager);
+            $this->truncateTables($connection);
         } else {
             try {
                 $doctrineService = $this->getObject(FlowDoctrineService::class);
@@ -59,20 +62,18 @@ trait FlowEntitiesTrait
                 $needsTruncate = true;
             }
 
-            $schema = $entityManager->getConnection()->getSchemaManager()->createSchema();
+            $schema = $connection->getSchemaManager()->createSchema();
             self::$databaseSchema = $schema;
 
             if ($needsTruncate) {
-                $this->truncateTables($entityManager);
+                $this->truncateTables($connection);
             }
         }
     }
 
     /** @internal */
-    private function truncateTables(EntityManagerInterface $entityManager): void
+    private function truncateTables(Connection $connection): void
     {
-        $connection = $entityManager->getConnection();
-
         /**
          * We respect flows option "ignoredTables" to preserve certain tables while resetting the database.
          * In our case we interpret everything in "ignoredTables" as not managed by doctrine.

--- a/Classes/FlowEntitiesTrait.php
+++ b/Classes/FlowEntitiesTrait.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Neos\Behat;
 
 use Behat\Hook\BeforeScenario;
-use Doctrine\DBAL\Exception as DoctrineException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Neos\Flow\Configuration\ConfigurationManager;
@@ -45,7 +45,7 @@ trait FlowEntitiesTrait
 
                 $doctrineService->executeMigrations();
                 $needsTruncate = true;
-            } catch (DoctrineException $exception) {
+            } catch (DBALException $exception) {
                 // Do an initial teardown to drop the schema cleanly
                 $this->getObject(PersistenceManagerInterface::class)->tearDown();
 

--- a/Classes/FlowEntitiesTrait.php
+++ b/Classes/FlowEntitiesTrait.php
@@ -47,6 +47,8 @@ trait FlowEntitiesTrait
                 $doctrineService = $this->getObject(FlowDoctrineService::class);
 
                 $doctrineService->executeMigrations();
+                // Hotfix reconnecting resets the currently active transactions
+                $connection->close();
                 $needsTruncate = true;
             } catch (DBALException $exception) {
                 // Do an initial teardown to drop the schema cleanly
@@ -54,6 +56,8 @@ trait FlowEntitiesTrait
 
                 $doctrineService = $this->getObject(FlowDoctrineService::class);
                 $doctrineService->executeMigrations();
+                // Hotfix reconnecting resets the currently active transactions
+                $connection->close();
                 $needsTruncate = false;
             } catch (\PDOException $exception) {
                 if ($exception->getMessage() !== 'There is no active transaction') {
@@ -69,6 +73,14 @@ trait FlowEntitiesTrait
                 $this->truncateTables($connection);
             }
         }
+
+       // \var_dump([
+       //     'getTransactionNestingLevel' => $connection->getTransactionNestingLevel(),
+       //     'isRollbackOnly' => $connection->isTransactionActive() ? $connection->isRollbackOnly() : null,
+       //     'isTransactionActive' => $connection->isTransactionActive(),
+       // ]);
+       // die();
+
     }
 
     /** @internal */

--- a/Tests/Behat/FlowContextTrait.php
+++ b/Tests/Behat/FlowContextTrait.php
@@ -12,7 +12,7 @@ namespace Neos\Behat\Tests\Behat;
  */
 
 use Behat\Hook\BeforeScenario;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 use Neos\Behat\FlowBootstrapTrait;
 use Neos\Behat\FlowEntitiesTrait;


### PR DESCRIPTION
When the database is empty, the doctrine migrations will be run via `executeMigrations`.
Though that leads to a transaction still being active:

```
array(2) {
  ["getTransactionNestingLevel"]=>
  int(119)
  ["isTransactionActive"]=>
  bool(true)
}
```

To work around this we close the connection, leading to the excepted state of no transaction. (The same state if the schema would already exist)

```
array(2) {
  ["getTransactionNestingLevel"]=>
  int(0)
  ["isTransactionActive"]=>
  bool(false)
}
```


This change is required for https://github.com/neos/neos-development-collection/pull/5284 so we can remove the hacky `./../flow doctrine:migrate` scripts in the CI.