### PR TITLE
BUGFIX: Allow custom behat subcontext via `FLOW_CONTEXT=Testing/Behat/Postgres`

### DIFF
--- a/Classes/FlowBootstrapTrait.php
+++ b/Classes/FlowBootstrapTrait.php
@@ -56,7 +56,7 @@ trait FlowBootstrapTrait
 
         // Boot flow with an active request handler
         $context = Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Testing/Behat';
-        if (preg_match('~^Testing/Behat(/[a-zA-Z]+)?$~', $context) !== 1) {
+        if (!($context === 'Testing/Behat' || str_starts_with($context, 'Testing/Behat/'))) {
             throw new \RuntimeException(sprintf('Invalid behat context %s. Expected to start with Testing/Behat', $context), 1776430103);
         }
         $flowBootstrap = new Bootstrap($context);

--- a/Classes/FlowBootstrapTrait.php
+++ b/Classes/FlowBootstrapTrait.php
@@ -55,7 +55,11 @@ trait FlowBootstrapTrait
         }
 
         // Boot flow with an active request handler
-        $flowBootstrap = new Bootstrap('Testing/Behat');
+        $context = Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Testing/Behat';
+        if (preg_match('~^Testing/Behat(/[a-zA-Z]+)?$~', $context) !== 1) {
+            throw new \RuntimeException(sprintf('Invalid behat context %s. Expected to start with Testing/Behat', $context), 1776430103);
+        }
+        $flowBootstrap = new Bootstrap($context);
         $requestHandler = new RuntimeSequenceHttpRequestHandler($flowBootstrap);
 
         $flowBootstrap->registerRequestHandler($requestHandler);


### PR DESCRIPTION
Currently the environment is ignored